### PR TITLE
Fix DatetimePickerField constructor

### DIFF
--- a/src/DateTimePickerField.php
+++ b/src/DateTimePickerField.php
@@ -23,7 +23,8 @@ class DatetimePickerField extends DatetimeField
     {
         parent::__construct($name, $title, $value);
 
-        $this->setTimeField(
+        $this->setField(
+            $name,
             TimepickerField::create($name . '[time]', false)
                 ->addExtraClass('fieldgroup-field')
         );


### PR DESCRIPTION
Update `setTimeField()` to `setField()` as `setTimeField()` no longer exists.